### PR TITLE
Patch 6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vers"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vers"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["ink8bit <ink8bit@users.noreply.github.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ vers minor --info "some changes"
 
 ```
 USAGE:
-    vers [FLAGS] [OPTIONS] <version>
+    vers [FLAGS] [OPTIONS] <version_type>
 
 ARGS:
-    <version>    [possible values: major, minor, patch]
+    <version_type>    [possible values: major, minor, patch]
 
 FLAGS:
     -h, --help         Prints help information
     -n, --no-commit    Prevents committing your changes
+    -V, --version      Prints version information
 
 OPTIONS:
     -i, --info <string>    Sets info value

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -35,7 +35,7 @@ impl Changelog<'_> {
 
 ### {date}
 
-**Releaser:** @{releaser}
+**Released by:** {releaser}
 ",
             version = e.version,
             date = date,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ pub(crate) fn args() -> ArgMatches {
         .about(crate_description!())
         .author(crate_authors!())
         .arg(
-            Arg::new("version")
+            Arg::new("version_type")
                 .index(1)
                 .possible_values(&["major", "minor", "patch"])
                 .required(true),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,6 @@ pub(crate) fn args() -> ArgMatches {
         .author(crate_authors!())
         .arg(
             Arg::new("version_type")
-                .index(1)
                 .possible_values(&["major", "minor", "patch"])
                 .required(true),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod cli;
 fn main() {
     let args = cli::args();
     let info = args.value_of("info").unwrap_or_default();
-    let version = args.value_of("version").unwrap();
+    let version = args.value_of("version_type").unwrap();
     let no_commit = args.is_present("no_commit");
 
     let v = vers::update(version, info, no_commit);


### PR DESCRIPTION
# Changes

- removed positional argument
- fixed changelog formatting:
  - changed **Releaser** field to **Released by**
  - removed `@` from releaser name
- fixed version `-V` command
