### PR TITLE
Patch 12

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,5 +36,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: cargo build --verbose
-      # - name: Run tests
-      # run: cargo test --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vers"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vers"
-version = "0.0.11"
+version = "0.0.12"
 authors = ["ink8bit <ink8bit@users.noreply.github.com>"]
 edition = "2018"
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -13,9 +13,9 @@ pub(crate) struct Changelog<'a> {
 
 pub(crate) struct Entry<'a> {
     pub version: &'a str,
-    pub changes: String,
-    pub releaser: String,
-    pub commits: String,
+    pub changes: &'a str,
+    pub releaser: &'a str,
+    pub commits: &'a str,
 }
 
 impl Changelog<'_> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,10 +2,26 @@ use std::error::Error;
 use std::process::Command;
 use std::str;
 
-pub(crate) fn commit(version: &str) -> Result<&str, std::io::Error> {
-    let ver_str = format!("Version bump: {}", version);
+pub(crate) fn commit<'a>(
+    version: &str,
+    releaser: &str,
+    info: &str,
+) -> Result<&'a str, std::io::Error> {
+    let mut comment = format!(
+        "Version bump: {v}
+
+Released by: {r}
+",
+        v = version,
+        r = releaser,
+    );
+
+    if !info.is_empty() {
+        comment.push_str(&info);
+    }
+
     let out = Command::new("git")
-        .args(&["commit", "-n", "--cleanup=strip", "-m", &ver_str])
+        .args(&["commit", "-n", "--cleanup=strip", "-m", &comment])
         .output();
 
     match out {
@@ -49,10 +65,22 @@ fn remote() -> Result<String, Box<dyn Error>> {
     Ok(stdout.to_string())
 }
 
-pub(crate) fn tag(v: &str) -> Result<String, std::io::Error> {
-    let version = format!("Version: {}", v);
+pub(crate) fn tag(v: &str, releaser: &str, info: &str) -> Result<String, std::io::Error> {
+    let mut comment = format!(
+        "Version: {v}
+
+Tagged by: {r}
+",
+        v = v,
+        r = releaser,
+    );
+
+    if !info.is_empty() {
+        comment.push_str(&info);
+    }
+
     let tag_cmd = Command::new("git")
-        .args(&["tag", "-a", v, "-m", &version])
+        .args(&["tag", "-a", v, "-m", &comment])
         .output();
 
     match tag_cmd {

--- a/src/git.rs
+++ b/src/git.rs
@@ -104,7 +104,7 @@ pub(crate) fn log() -> Result<String, Box<dyn Error>> {
             "log",
             "--pretty=format:%h | %an: %s",
             "--no-merges",
-            "master...HEAD",
+            "master..HEAD",
             "--reverse",
         ])
         .output()?;

--- a/src/git.rs
+++ b/src/git.rs
@@ -9,7 +9,7 @@ pub(crate) fn commit<'a>(
 ) -> Result<&'a str, std::io::Error> {
     let comment = create_comment(&version, &releaser, &info, false);
     let out = Command::new("git")
-        .args(&["commit", "-n", "--cleanup=strip", "-m", &comment.trim()])
+        .args(&["commit", "-n", "--cleanup=strip", "-m", &comment])
         .output();
 
     match out {
@@ -70,7 +70,7 @@ fn create_comment(v: &str, releaser: &str, info: &str, is_tag: bool) -> String {
         comment.push_str(&format!("\nInfo: {}", info));
     }
 
-    comment
+    comment.trim().to_string()
 }
 
 pub(crate) fn tag(version: &str, releaser: &str, info: &str) -> Result<String, std::io::Error> {
@@ -202,7 +202,7 @@ Info: {i}",
         let fake_info = "";
 
         let actual = create_comment(fake_version, fake_user_name, fake_info, true);
-        let expected = format!("Version bump: {v}\n", v = fake_version,);
+        let expected = format!("Version bump: {v}", v = fake_version,);
 
         assert_eq!(actual, expected);
     }
@@ -214,7 +214,7 @@ Info: {i}",
         let fake_info = "";
 
         let actual = create_comment(fake_version, fake_user_name, fake_info, false);
-        let expected = format!("Version bump: {v}\n", v = fake_version,);
+        let expected = format!("Version bump: {v}", v = fake_version,);
 
         assert_eq!(actual, expected);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,14 +66,14 @@ pub fn update(version: &str, info: &str, no_commit: bool) -> Result<String, Vers
     }
 
     let v = npm::version(version).map_err(|_| VersError::VersionUpdate)?;
-    let releaser = releaser()?;
+    let r = releaser()?;
     let commits = git::log().map_err(|_| VersError::GitStatus)?;
 
     let e = Entry {
         version: &v,
-        changes: info.to_string(),
-        releaser,
-        commits,
+        changes: info,
+        releaser: &r,
+        commits: &commits,
     };
 
     let log = Changelog { entry: e };
@@ -87,10 +87,10 @@ pub fn update(version: &str, info: &str, no_commit: bool) -> Result<String, Vers
 
     git::add_all().map_err(|_| VersError::GitAddAll)?;
 
-    let commit_msg = git::commit(&v).map_err(|_| VersError::GitCommit)?;
+    let commit_msg = git::commit(&v, &r, info).map_err(|_| VersError::GitCommit)?;
     println!("{}", commit_msg);
 
-    let tag_msg = git::tag(&v).map_err(|_| VersError::GitTag)?;
+    let tag_msg = git::tag(&v, &r, info).map_err(|_| VersError::GitTag)?;
     println!("{}", tag_msg);
 
     let push_msg = git::push().map_err(|_| VersError::GitPush)?;
@@ -100,13 +100,13 @@ pub fn update(version: &str, info: &str, no_commit: bool) -> Result<String, Vers
 }
 
 /// Commit and tag changes
-pub fn save_changes(v: &str) -> Result<(), VersError> {
+pub fn save_changes(v: &str, releaser_name: &str, info: &str) -> Result<(), VersError> {
     git::add_all().map_err(|_| VersError::GitAddAll)?;
 
-    let commit_msg = git::commit(&v).map_err(|_| VersError::GitCommit)?;
+    let commit_msg = git::commit(&v, &releaser_name, &info).map_err(|_| VersError::GitCommit)?;
     println!("{}", commit_msg);
 
-    let tag_msg = git::tag(&v).map_err(|_| VersError::GitTag)?;
+    let tag_msg = git::tag(&v, &releaser_name, &info).map_err(|_| VersError::GitTag)?;
     println!("{}", tag_msg);
 
     Ok(())


### PR DESCRIPTION
# Changes

- Fixed `git log` command
- Changed commit and tag message
- Turned on tests in workflow
- Added additional arguments (`releaser` and `info`) to methods:
  - `save_changes`
  - `push_changes`