### PR TITLE
Patch 14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vers"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vers"
-version = "0.0.13"
+version = "0.0.14"
 authors = ["ink8bit <ink8bit@users.noreply.github.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ You should add `vers` crate to your *Cargo.toml* file:
 vers = { git = "https://github.com/ink8bit/vers", branch = "master" }
 ```
 
-And use this crate in the following way:
+### Public API
+
+- [update](#update) - updates `CHANGELOG.md`, `package.json`, `package-lock.json` (if exists), commits changes, creates tag and pushes changes to the remote.
+- [save_changes](#save_changes) - creates commit and tag
+- [push_changes](#push_changes) - pushes changes to the remote
+
+#### `update` function
 
 ```rust
 match vers::update("minor", "changes", false) {
@@ -63,20 +69,19 @@ match vers::update("minor", "changes", false) {
 }
 ```
 
-There are two more public functions you can use:
-
-- `save_changes` - to commit and tag your changes with a provided version string
-- `push_changes` - to upload your changes to the remote
-
-Be sure to check for errors while using these two functions:
+#### `save_changes` function
 
 ```rust
-if let Err(e) = vers::save_changes(&v) {
+if let Err(e) = vers::save_changes(&v, releaser_name: "username", info: "some info") {
     panic!(e);
 }
+```
 
+#### `push_changes` function
+
+```rust
 if let Err(e) = vers::push_changes() {
-    eprintln!("{}", e);
+    panic!(e);
 }
 ```
 
@@ -98,7 +103,11 @@ List of commits in feature branch
 
 ### Using github username
 
-You can use your GitHub username in **Released by:** field of your *CHANGELOG* file instead of *git* user name and email.
+You can use your GitHub username in:
+- `Released by:` field of your _CHANGELOG.md_ file
+- `Tagged by:` field in your tag
+- `Released by:` field in your commit message
+
 You need to set env variable `VERS_GITHUB_NAME`. For example:
 
 ```

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ List of commits in feature branch
 ### Using github username
 
 You can use your GitHub username in:
-- `Released by:` field of your _CHANGELOG.md_ file
+- `Released by:` field in your _CHANGELOG.md_ file
 - `Tagged by:` field in your tag
 - `Released by:` field in your commit message
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ vers = { git = "https://github.com/ink8bit/vers", branch = "master" }
 - [update](#update) - updates `CHANGELOG.md`, `package.json`, `package-lock.json` (if exists), commits changes, creates tag and pushes changes to the remote.
 - [save_changes](#save_changes) - creates commit and tag
 - [push_changes](#push_changes) - pushes changes to the remote
+- [releaser](#releaser) - returns your git user name and user email, or your GitHub handle if you set env var [VERS_GITHUB_NAME](#using-github-username)
+- [current_branch_name](#current_branch_name) - returns current git branch value
 
-#### `update` function
+#### `update`
 
 ```rust
 match vers::update("minor", "changes", false) {
@@ -69,7 +71,7 @@ match vers::update("minor", "changes", false) {
 }
 ```
 
-#### `save_changes` function
+#### `save_changes`
 
 ```rust
 if let Err(e) = vers::save_changes(&v, releaser_name: "username", info: "some info") {
@@ -77,12 +79,30 @@ if let Err(e) = vers::save_changes(&v, releaser_name: "username", info: "some in
 }
 ```
 
-#### `push_changes` function
+#### `push_changes`
 
 ```rust
 if let Err(e) = vers::push_changes() {
     panic!(e);
 }
+```
+
+#### releaser
+
+```rust
+let releaser = match vers::releaser() {
+    Ok(value) => value,
+    Err(e) => panic!(e),
+};
+```
+
+#### `current_branch_name`
+
+```rust
+let branch = match vers::current_branch_name() {
+    Ok(value) => value,
+    Err(e) => panic!(e),
+};
 ```
 
 ## Changelog format

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ In general, `vers` does the following:
 - creates an annotated git tag
 - and pushes changes
 
+`vers` works only with _git_.
+
 ## How to use
 
 You can use it as a binary or as a library.
@@ -87,7 +89,7 @@ if let Err(e) = vers::push_changes() {
 }
 ```
 
-#### releaser
+#### `releaser`
 
 ```rust
 let releaser = match vers::releaser() {

--- a/src/git.rs
+++ b/src/git.rs
@@ -23,7 +23,7 @@ pub(crate) fn add_all() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn branch() -> Result<String, Box<dyn Error>> {
+pub(crate) fn branch() -> Result<String, Box<dyn Error>> {
     let current_branch = branch_name()?;
     if !current_branch.is_empty() {
         return Ok(current_branch);
@@ -53,21 +53,18 @@ fn branch_name_fallback() -> Result<String, Box<dyn Error>> {
     Ok(stdout.to_string())
 }
 
-pub(crate) fn push() -> Result<String, Box<dyn Error>> {
-    let branch_name = branch()?;
-    let origin = remote()?;
-
+pub(crate) fn push(branch: &str, remote_name: &str) -> Result<String, Box<dyn Error>> {
     let _out = Command::new("git")
-        .args(&["push", "--follow-tags", origin.as_str(), &branch_name])
+        .args(&["push", "--follow-tags", remote_name, &branch])
         .output()?;
 
     Ok(format!(
         "Successfully pushed changes to remote branch '{}'",
-        branch_name
+        branch
     ))
 }
 
-fn remote() -> Result<String, Box<dyn Error>> {
+pub(crate) fn remote() -> Result<String, Box<dyn Error>> {
     let out = Command::new("git").arg("remote").output()?;
     let stdout = str::from_utf8(&out.stdout)?.trim();
 
@@ -90,7 +87,6 @@ fn create_comment(v: &str, releaser: &str, info: &str, is_tag: bool) -> String {
     if !info.is_empty() {
         comment.push_str(&format!("\nInfo: {}", info));
     }
-
     comment.trim().to_string()
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -24,8 +24,29 @@ pub(crate) fn add_all() -> Result<(), Box<dyn Error>> {
 }
 
 fn branch() -> Result<String, Box<dyn Error>> {
+    let current_branch = branch_name()?;
+    if !current_branch.is_empty() {
+        return Ok(current_branch);
+    }
+    let current_branch_fallback = branch_name_fallback()?;
+    Ok(current_branch_fallback)
+}
+
+/// Returns current `git` branch name
+fn branch_name() -> Result<String, Box<dyn Error>> {
     let out = Command::new("git")
         .args(&["branch", "--show-current"])
+        .output()?;
+    let stdout = str::from_utf8(&out.stdout)?.trim();
+
+    Ok(stdout.to_string())
+}
+
+/// Returns current git branch name.
+/// It's only to support previous `git` versions
+fn branch_name_fallback() -> Result<String, Box<dyn Error>> {
+    let out = Command::new("git")
+        .args(&["rev-parse", "--abbrev-ref", "HEAD"])
         .output()?;
     let stdout = str::from_utf8(&out.stdout)?.trim();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,3 +157,12 @@ pub fn push_changes() -> Result<(), VersError> {
 
     Ok(())
 }
+
+/// Returns current git branch value
+pub fn current_branch_name() -> Result<String, VersError> {
+    let branch_name = git::branch().map_err(|_| VersError::GitBranch)?;
+    if branch_name.is_empty() {
+        return Err(VersError::GitBranch);
+    }
+    Ok(branch_name)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ use std::{env, fmt, path::Path};
 pub enum VersError {
     GitName,
     GitEmail,
+    GitBranch,
+    GitOrigin,
     GitStatus,
     GitLog,
     GitAddAll,
@@ -26,6 +28,8 @@ impl fmt::Display for VersError {
         match self {
             VersError::GitName => write!(f, "Could not get git user name"),
             VersError::GitEmail => write!(f, "Could not get git user email"),
+            VersError::GitBranch => write!(f, "Could not get current git branch value"),
+            VersError::GitOrigin => write!(f, "Could not get git remote name"),
             VersError::GitStatus => write!(f, "Could not execute git status"),
             VersError::GitLog => write!(f, "Unable to collect your commits"),
             VersError::GitAddAll => write!(f, "Unable to add your changes to staging area"),
@@ -102,7 +106,9 @@ pub fn update(version: &str, info: &str, no_commit: bool) -> Result<String, Vers
     let tag_msg = git::tag(&v, &r, info).map_err(|_| VersError::GitTag)?;
     println!("{}", tag_msg);
 
-    let push_msg = git::push().map_err(|_| VersError::GitPush)?;
+    let current_branch = git::branch().map_err(|_| VersError::GitBranch)?;
+    let remote_name = git::remote().map_err(|_| VersError::GitOrigin)?;
+    let push_msg = git::push(&current_branch, &remote_name).map_err(|_| VersError::GitPush)?;
     println!("{}", push_msg);
 
     Ok(v)
@@ -130,7 +136,9 @@ pub fn save_changes(version: &str, releaser_name: &str, info: &str) -> Result<()
 
 /// Pushes changes to the remote
 pub fn push_changes() -> Result<(), VersError> {
-    let msg = git::push().map_err(|_| VersError::GitPush)?;
+    let current_branch = git::branch().map_err(|_| VersError::GitBranch)?;
+    let remote_name = git::remote().map_err(|_| VersError::GitOrigin)?;
+    let msg = git::push(&current_branch, &remote_name).map_err(|_| VersError::GitPush)?;
     println!("{}", msg);
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub fn push_changes() -> Result<(), VersError> {
     Ok(())
 }
 
-/// Returns current git branch value
+/// Returns current `git` branch value
 pub fn current_branch_name() -> Result<String, VersError> {
     let branch_name = git::branch().map_err(|_| VersError::GitBranch)?;
     if branch_name.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub enum VersError {
     GitName,
     GitEmail,
     GitBranch,
-    GitOrigin,
+    GitRemote,
     GitStatus,
     GitLog,
     GitAddAll,
@@ -29,7 +29,7 @@ impl fmt::Display for VersError {
             VersError::GitName => write!(f, "Could not get git user name"),
             VersError::GitEmail => write!(f, "Could not get git user email"),
             VersError::GitBranch => write!(f, "Could not get current git branch value"),
-            VersError::GitOrigin => write!(f, "Could not get git remote name"),
+            VersError::GitRemote => write!(f, "Could not get git remote name"),
             VersError::GitStatus => write!(f, "Could not execute git status"),
             VersError::GitLog => write!(f, "Unable to collect your commits"),
             VersError::GitAddAll => write!(f, "Unable to add your changes to staging area"),
@@ -107,7 +107,13 @@ pub fn update(version: &str, info: &str, no_commit: bool) -> Result<String, Vers
     println!("{}", tag_msg);
 
     let current_branch = git::branch().map_err(|_| VersError::GitBranch)?;
-    let remote_name = git::remote().map_err(|_| VersError::GitOrigin)?;
+    if current_branch.is_empty() {
+        return Err(VersError::GitBranch);
+    }
+    let remote_name = git::remote().map_err(|_| VersError::GitRemote)?;
+    if remote_name.is_empty() {
+        return Err(VersError::GitRemote);
+    }
     let push_msg = git::push(&current_branch, &remote_name).map_err(|_| VersError::GitPush)?;
     println!("{}", push_msg);
 
@@ -137,7 +143,15 @@ pub fn save_changes(version: &str, releaser_name: &str, info: &str) -> Result<()
 /// Pushes changes to the remote
 pub fn push_changes() -> Result<(), VersError> {
     let current_branch = git::branch().map_err(|_| VersError::GitBranch)?;
-    let remote_name = git::remote().map_err(|_| VersError::GitOrigin)?;
+    if current_branch.is_empty() {
+        return Err(VersError::GitBranch);
+    }
+
+    let remote_name = git::remote().map_err(|_| VersError::GitRemote)?;
+    if remote_name.is_empty() {
+        return Err(VersError::GitRemote);
+    }
+
     let msg = git::push(&current_branch, &remote_name).map_err(|_| VersError::GitPush)?;
     println!("{}", msg);
 

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -2,6 +2,9 @@ use std::error::Error;
 use std::process::Command;
 use std::str;
 
+/// Updates `package.json` and `package-lock.json` _version_ field
+///
+/// Uses `npm version` command under the hood
 pub(crate) fn version(ver_type: &str) -> Result<String, Box<dyn Error>> {
     let out = Command::new("npm")
         .args(&[


### PR DESCRIPTION
# Changes
- Added functions to get current branch name:
  - `branch_name`
  - `branch_name_fallback` (for previous git versions)
- Added **Public API** section with examples to _README_
- Added docs to source code

## Internal

- git module:
  - push function accepts two arguments: _current git branch name_ and _remote name_

## Public API
- added new function `current_branch` which returns current git branch value