### PR TITLE
Patch 17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vers"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vers"
-version = "0.0.16"
+version = "0.0.17"
 authors = ["ink8bit <ink8bit@users.noreply.github.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ vers = { git = "https://github.com/ink8bit/vers", branch = "master" }
 
 ### Public API
 
-- [update](#update) - updates `CHANGELOG.md`, `package.json`, `package-lock.json` (if exists), commits changes, creates tag and pushes changes to the remote.
-- [save_changes](#save_changes) - creates commit and tag
-- [push_changes](#push_changes) - pushes changes to the remote
+- [update](#update) - updates `CHANGELOG.md`, `package.json`, `package-lock.json` (if exists), commits changes, creates tag and pushes changes to the remote. Returns created version value.
+- [save_changes](#save_changes) - creates commit and tag. Returns created tag value.
+- [push_changes](#push_changes) - pushes changes to the remote. Returns current git branch value.
 - [releaser](#releaser) - returns your git user name and user email, or your GitHub handle if you set env var [VERS_GITHUB_NAME](#using-github-username)
 - [current_branch_name](#current_branch_name) - returns current git branch value
 
@@ -76,16 +76,18 @@ match vers::update("minor", "changes", false) {
 #### `save_changes`
 
 ```rust
-if let Err(e) = vers::save_changes("v1.2.3", "releaser", "some info") {
-    panic!("{}", e);
+match vers::save_changes("v1.2.3", "releaser", "some info") {
+    Ok(v) => println!("Created tag: {}", v),
+    Err(e) => eprintln!("{}", e),
 }
 ```
 
 #### `push_changes`
 
 ```rust
-if let Err(e) = vers::push_changes() {
-    panic!("{}", e);
+match vers::push_changes() {
+    Ok(v) => println!("Current git branch: {}", v),
+    Err(e) => eprintln!("{}", e),
 }
 ```
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -19,11 +19,11 @@ pub(crate) struct Entry<'a> {
 }
 
 impl Changelog<'_> {
-    pub(crate) fn update(&self) -> Result<String, Box<dyn Error>> {
+    pub(crate) fn update(&self) -> Result<(), Box<dyn Error>> {
         let formatted = self.format(&self.entry);
         let _res = self.write(formatted)?;
 
-        Ok(format!("{} updated", CHANGELOG_FILE_NAME))
+        Ok(())
     }
 
     fn format(&self, e: &Entry) -> String {

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,18 +5,14 @@ use std::str;
 /// Commits your changes without running pre-commit hooks
 ///
 /// Uses `git commit -n --cleanup=strip -m <message>` command under the hood
-pub(crate) fn commit<'a>(
-    version: &str,
-    releaser: &str,
-    info: &str,
-) -> Result<&'a str, std::io::Error> {
+pub(crate) fn commit(version: &str, releaser: &str, info: &str) -> Result<(), std::io::Error> {
     let comment = create_comment(&version, &releaser, &info, false);
     let out = Command::new("git")
         .args(&["commit", "-n", "--cleanup=strip", "-m", &comment])
         .output();
 
     match out {
-        Ok(_) => Ok("Successfully committed changes"),
+        Ok(_) => Ok(()),
         Err(e) => Err(e),
     }
 }
@@ -76,10 +72,7 @@ pub(crate) fn push(branch: &str, remote_name: &str) -> Result<String, Box<dyn Er
         .args(&["push", "--follow-tags", remote_name, &branch])
         .output()?;
 
-    Ok(format!(
-        "Successfully pushed changes to remote branch '{}'",
-        branch
-    ))
+    Ok(branch.to_string())
 }
 
 /// Returns `git` remote value
@@ -135,7 +128,7 @@ pub(crate) fn tag(version: &str, releaser: &str, info: &str) -> Result<String, s
         .output();
 
     match tag_cmd {
-        Ok(_) => Ok(format!("Successfully created new tag {}", version)),
+        Ok(_) => Ok(version.to_string()),
         Err(e) => Err(e),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,11 @@ use changelog::{Changelog, Entry};
 use std::{env, fmt, path::Path};
 
 const COMMIT_MSG: &str = "Committing...";
+const COMMIT_SUCCESS_MSG: &str = "Successfully committed your changes";
 const TAG_MSG: &str = "Tagging...";
+const TAG_SUCCESS_MSG: &str = "Successfully created tag";
 const PUSH_MSG: &str = "Pushing...";
+const PUSH_SUCCESS_MSG: &str = "Successfully pushed your changes to remote branch";
 
 #[derive(Debug)]
 pub enum VersError {
@@ -110,12 +113,12 @@ pub fn update(version: &str, info: &str, no_commit: bool) -> Result<String, Vers
     git::add_all().map_err(|_| VersError::GitAddAll)?;
 
     let sp = spinner(COMMIT_MSG);
-    let commit_msg = git::commit(&v, &r, info).map_err(|_| VersError::GitCommit)?;
-    spinner_text(sp, &commit_msg);
+    git::commit(&v, &r, info).map_err(|_| VersError::GitCommit)?;
+    spinner_text(sp, COMMIT_SUCCESS_MSG);
 
     let sp = spinner(TAG_MSG);
-    let tag_msg = git::tag(&v, &r, info).map_err(|_| VersError::GitTag)?;
-    spinner_text(sp, &tag_msg);
+    let tag = git::tag(&v, &r, info).map_err(|_| VersError::GitTag)?;
+    spinner_text(sp, &format!("{} {}", TAG_SUCCESS_MSG, tag));
 
     let sp = spinner(PUSH_MSG);
     let current_branch = git::branch().map_err(|_| VersError::GitBranch)?;
@@ -126,8 +129,8 @@ pub fn update(version: &str, info: &str, no_commit: bool) -> Result<String, Vers
     if remote_name.is_empty() {
         return Err(VersError::GitRemote);
     }
-    let push_msg = git::push(&current_branch, &remote_name).map_err(|_| VersError::GitPush)?;
-    spinner_text(sp, &push_msg);
+    let branch = git::push(&current_branch, &remote_name).map_err(|_| VersError::GitPush)?;
+    spinner_text(sp, &format!("{} {}", PUSH_SUCCESS_MSG, branch));
 
     Ok(v)
 }
@@ -143,13 +146,12 @@ pub fn save_changes(version: &str, releaser_name: &str, info: &str) -> Result<()
     git::add_all().map_err(|_| VersError::GitAddAll)?;
 
     let sp = spinner(COMMIT_MSG);
-    let commit_msg =
-        git::commit(&version, &releaser_name, &info).map_err(|_| VersError::GitCommit)?;
-    spinner_text(sp, &commit_msg);
+    git::commit(&version, &releaser_name, &info).map_err(|_| VersError::GitCommit)?;
+    spinner_text(sp, COMMIT_SUCCESS_MSG);
 
     let sp = spinner(TAG_MSG);
-    let tag_msg = git::tag(&version, &releaser_name, &info).map_err(|_| VersError::GitTag)?;
-    spinner_text(sp, &tag_msg);
+    let tag = git::tag(&version, &releaser_name, &info).map_err(|_| VersError::GitTag)?;
+    spinner_text(sp, &format!("{} {}", TAG_SUCCESS_MSG, tag));
 
     Ok(())
 }
@@ -167,8 +169,8 @@ pub fn push_changes() -> Result<(), VersError> {
         return Err(VersError::GitRemote);
     }
 
-    let msg = git::push(&current_branch, &remote_name).map_err(|_| VersError::GitPush)?;
-    spinner_text(sp, &msg);
+    let branch = git::push(&current_branch, &remote_name).map_err(|_| VersError::GitPush)?;
+    spinner_text(sp, &format!("{} {}", PUSH_SUCCESS_MSG, branch));
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,9 +101,7 @@ pub fn update(version: &str, info: &str, no_commit: bool) -> Result<String, Vers
     };
 
     let log = Changelog { entry: e };
-
-    let update_msg = log.update().map_err(|_| VersError::LogUpdate)?;
-    println!("{}", update_msg);
+    log.update().map_err(|_| VersError::LogUpdate)?;
 
     if no_commit {
         return Ok(v);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+use colored::*;
+use terminal_spinners::{SpinnerBuilder, DOTS};
+
 mod cli;
 
 fn main() {
@@ -6,8 +9,23 @@ fn main() {
     let version = args.value_of("version_type").unwrap();
     let no_commit = args.is_present("no_commit");
 
+    let sp = SpinnerBuilder::new()
+        .spinner(&DOTS)
+        .text("Updating...")
+        .start();
+
     match vers::update(version, info, no_commit) {
-        Ok(v) => println!("Updated version: {}", v),
-        Err(e) => eprintln!("{}", e),
+        Ok(v) => {
+            let msg = format!("Successfully created version {}", v)
+                .green()
+                .to_string();
+            sp.text(msg);
+            sp.done();
+        }
+        Err(e) => {
+            let err_msg = format!("Error: {}", e).red().to_string();
+            sp.text(err_msg);
+            sp.done();
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
 
     let sp = SpinnerBuilder::new()
         .spinner(&DOTS)
-        .text("Updating...")
+        .text(" Updating...")
         .start();
 
     match vers::update(version, info, no_commit) {
@@ -25,7 +25,7 @@ fn main() {
         Err(e) => {
             let err_msg = format!("Error: {}", e).red().to_string();
             sp.text(err_msg);
-            sp.done();
+            sp.error();
         }
     }
 }


### PR DESCRIPTION
# Changes

- updated readme

## Internal

- Removed _changelog_ creation message

## API

- changed library methods:
  - `update` - returns an updated version string
  - `save_changes` - returns a created tag value
  - `push_changes` - returns a current git branch
- show a spinner in a CLI app while updating version